### PR TITLE
Pipeline resources

### DIFF
--- a/src/fpipeline/fpipeline.py
+++ b/src/fpipeline/fpipeline.py
@@ -11,8 +11,9 @@ from fpipeline.steps import *
 from ._version import *
 
 FPIPELINE_ALL: list[str] = [
-    'Step', 'Condition', 'Pipeline',
-    'pipeline', 'variables', context, 'stepfn', 'conditionfn',
+    'Step', 'Condition', 'Pipeline', 'Closeable',
+    'pipeline', 'variables', 'Resource',
+    'context', 'stepfn', 'conditionfn',
     'if_', 'not_', 'and_', 'or_',
     'Variable', 'Attribute', 'VariableContext', 'PipelineContext',
     'store', 'eval_vars',

--- a/src/fpipeline/types.py
+++ b/src/fpipeline/types.py
@@ -3,7 +3,9 @@ Core types
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, Sequence
+from typing import (
+    Callable, Optional, Sequence, Protocol, runtime_checkable,
+)
 
 class Step[C,V](ABC):
     """
@@ -92,3 +94,11 @@ type Value[V] = V \
     |dict[str,Arg[V]] \
     |set[Arg[V]] \
     |frozenset[Arg[V]]
+
+@runtime_checkable
+class Closeable(Protocol):
+    """An abstract class for objects implementing a close method."""
+    def close(self) -> None:
+        ...
+
+type ContextFactory[C] = Callable[[], C]


### PR DESCRIPTION
Add pipeline resources.

These accept context managers or closable objects, and arrange for closing when contexts go out of scope.

This also adds nested contexts, to allow finer-grained lifetimes.