### PR TITLE
@step_ and @condition_ decorators default to returning the context.

### DIFF
--- a/src/fpipeline/decorators.py
+++ b/src/fpipeline/decorators.py
@@ -3,7 +3,7 @@ Decorators for fpipeline step and condition functions.
 """
 
 from typing import (
-    Callable, Concatenate, cast,
+    Callable, Concatenate, Optional, cast, overload,
     )
 from functools import wraps
 
@@ -12,7 +12,7 @@ from .functions import curry
 
 ### Annotations
 
-def stepfn[C,V, **P](fnx: Callable[Concatenate[C, P], V]) -> Callable[P, Step[C, V]]:
+def stepfn[C,V, **P](fnx: Optional[Callable[Concatenate[C,P], V]] = None) -> Callable[P, Step[C, V]]:
     """
     An annotation for defining step functions. All but the first argument are curried.
     
@@ -31,10 +31,56 @@ def stepfn[C,V, **P](fnx: Callable[Concatenate[C, P], V]) -> Callable[P, Step[C,
         V: The return type
         P: The arguments type
     """
-    @wraps(fnx)
+    return step_(fnx, _final=True)
+
+@overload
+def step_[C, V, **P](fnx: Optional[Callable[Concatenate[C,P], V]] = None) -> Callable[P, Step[C, C]]:
+    ...
+@overload
+def step_[C, V, **P](_final: True) -> Callable[P, Step[C, V]]:
+    ...
+@overload
+def step_[C, **P](_final: False) -> Callable[P, Step[C, C]]:
+    ...
+@overload
+def step_[C, V, **P](_final: bool) -> Callable[P, Step[C, V]|Step[C, C]]:
+    ...
+def step_[C,V, **P](fnx: Optional[Callable[Concatenate[C,P],V]] = None, /,
+                    _final: bool=False
+                    ) -> Callable[P, Step[C, V]]|Step[C,C]|Step[C,V]:
+    """
+    An annotation for defining step functions. All but the first argument are curried.
+    
+    Parameters
+    ----------
+        fnx : `Callable[Concatenate[C, P], V]`
+            The function to be annotated
+        _final : bool, optional, keyword-only
+            If True, the return type of the step function will be `Step[C, V]` instead of `Step[C, C]`
+
+    Returns
+    -------
+        Callable[P, Step[C, C]] - a function that accepts the given arguments and returns a step function.
+        Callable[P, Step[C, V]] - a function that accepts the given arguments and returns a step function, if _final=True
+
+    Type Parameters
+    ---------------
+        C: The context type
+        V: The return type
+        P: The arguments type
+    """
     def step_fn(*args: P.args, **kwargs: P.kwargs) -> Step[C,V]:
-        return curry(fnx, *args, **kwargs) # type: ignore
-    return step_fn
+        if _final:
+            return wraps(fnx)(curry(fnx, *args, **kwargs))
+        def step_fn_return(ctx: C) -> V:
+            fnx(ctx, *args, **kwargs)
+            return ctx
+        return wraps(fnx)(step_fn_return) # type: ignore
+    if fnx:
+        return wraps(fnx)(step_fn)
+    def step_fn_(fnx: Callable[Concatenate[C,P], V]) -> Step[C,V]:
+        return wraps(fnx)(step_fn)
+    return wraps(step_)
 
 def conditionfn[C,**P](fnx: Callable[Concatenate[C, P], bool]) -> Callable[P, Condition[C]]:
     """
@@ -54,7 +100,24 @@ def conditionfn[C,**P](fnx: Callable[Concatenate[C, P], bool]) -> Callable[P, Co
         C: The context type
         P: The arguments type
     """
-    @wraps(fnx)
-    def condition_fn(*args: P.args, **kwargs: P.kwargs) -> Condition[C]:
-        return curry(fnx, *args, **kwargs) # type: ignore
-    return condition_fn
+    return condition_(fnx)
+
+def condition_[C,V,**P](fnx: Optional[Callable[Concatenate[C,P], V]] = None) -> Callable[P, Condition[C]]:
+    """
+    An annotation for defining step functions. All but the first argument are curried.
+    
+    Parameters
+    ----------
+        fnx : `Callable[Concatenate[C, P], bool]`
+            The function to be annotated
+
+    Returns
+    -------
+        `Callable[P, Condition[C]]` - a function that accepts the given arguments and returns a condition function.
+
+    Type Parameters
+    ---------------
+        C: The context type
+        P: The arguments type
+    """
+    return cast(Condition[C], step_(fnx, _final=True))


### PR DESCRIPTION
* Add `@step` and `@condition_` decorators as more flexible alternatives to
`@stepFn` and `@conditionFn` (which are retained for compatibility).

`@step_` defaults to returning the context; this can be overridden via this pattern:

```Python
@step_(_final=True)
def myStep(ctx: PipelineContext, arg1: int) -> str:
    ...
```
This creates a `Step[PipelineContext, str]` that returns a string, rather than its first argument.

This is useful in the final stage of a pipeline.

* Also fixes decorated function names.